### PR TITLE
Improve positioning of ErrorsFrame

### DIFF
--- a/src/main/java/qe/gui/ErrorsFrame.java
+++ b/src/main/java/qe/gui/ErrorsFrame.java
@@ -34,7 +34,8 @@ public class ErrorsFrame {
 	 * @return
 	 */
 	public ErrorsFrame initialize() {
-		frame.setBounds(90, 90, 682, 449);
+	    frame.setLocationByPlatform(true);
+	    frame.setSize(900, 449);
 		frame.setDefaultCloseOperation(JFrame.HIDE_ON_CLOSE);
 		frame.setTitle(title);
 		JPanel panel = new JPanel();


### PR DESCRIPTION
- use setLocationByPlatform so that it is not opened on a different
  monitor than the main window
- increase the width somewhat so that the need to resize is less likely
